### PR TITLE
Update package name in examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ installed before you try running this.
 ```js
 var stylesheet = fs.readFileSync('path/to/my/stylesheet', 'utf-8'),
     xmlContent = fs.readFileSync('path/to/xml/doc', 'utf-8'),
-    fluxslt = require('fluent-xslt');
+    fluxslt = require('fluxslt');
 
 fluxslt()
     .withStylesheet(stylesheet)
@@ -24,7 +24,7 @@ fluxslt()
 
 ```js
 var xmlContent = fs.readFileSync('path/to/xml/doc', 'utf-8'),
-    fluxslt = require('fluent-xslt');
+    fluxslt = require('fluxslt');
 
 fluxslt()
     .withStylesheetPath('path/to/my/stylesheet')


### PR DESCRIPTION
The package name was changed in package.json on 2015-08-21
(commit 2a90fc5),
but the examples in the README.md file were not updated.